### PR TITLE
Bump runtime to `master`

### DIFF
--- a/io.github.bytezz.IPLookup.json
+++ b/io.github.bytezz.IPLookup.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.bytezz.IPLookup",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "44",
+    "runtime-version" : "master",
     "sdk" : "org.gnome.Sdk",
     "command" : "iplookup",
     "finish-args" : [


### PR DESCRIPTION
Since we're using this repo's manifest for testing purposes, we should use the `master` runtime to port the latest widgets before the stable versions are released.

You can get the `master` version of the GNOME runtime from [GNOME Nightly](https://wiki.gnome.org/Apps/Nightly).