### PR TITLE
Mostly appdata related patches

### DIFF
--- a/data/io.github.bytezz.IPLookup.appdata.xml.in
+++ b/data/io.github.bytezz.IPLookup.appdata.xml.in
@@ -2,7 +2,7 @@
 <component type="desktop">
 	<id>io.github.bytezz.IPLookup</id>
 	<name>IP Lookup</name>
-	<summary>Find info about an IP address.</summary>
+	<summary>Find info about an IP address</summary>
 	<icon type="remote" width="16" height="16" scale="1">https://raw.githubusercontent.com/Bytezz/IPLookup-gtk/master/data/icons/hicolor/scalable/apps/io.github.bytezz.IPLookup.svg</icon>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0-or-later</project_license>
@@ -11,17 +11,14 @@
 	</description>
 	<content_rating type="oars-1.1"/>
 	<launchable type="desktop-id">io.github.bytezz.IPLookup.desktop</launchable>
+	<translation type="gettext">iplookup</translation>
 
 	<screenshots>
-		<screenshot width="622" height="837">
+		<screenshot width="622" height="837" type="default">
 			<caption>Main Window</caption>
 			<image type="source">https://raw.githubusercontent.com/Bytezz/IPLookup-gtk/master/screenshot/window.png</image>
 		</screenshot>
 	</screenshots>
-
-	<categories>
-		<category>Utility</category>
-	</categories>
 
 	<recommends>
 		<control>keyboard</control>
@@ -33,61 +30,55 @@
 		<internet>always</internet>
 	</requires>
 
-	<keywords>
-		<keyword>IP</keyword>
-		<keyword>lookup</keyword>
-		<keyword>ISP</keyword>
-		<keyword>traceroute</keyword>
-	</keywords>
-
 	<url type="homepage">https://github.com/bytezz/iplookup-gtk</url>
 	<url type="bugtracker">https://github.com/Bytezz/IPLookup-gtk/issues</url>
+	<url type="vcs-browser">https://github.com/bytezz/iplookup-gtk</url>
+	<url type="translate">https://github.com/Bytezz/IPLookup-gtk/tree/main/po</url>
 
 	<custom>
-		<value key="Purism::form_factor">workstation</value>
 		<value key="Purism::form_factor">mobile</value>
 	</custom>
 
 	<releases>
 		<release version="0.1.7" date="2023-06-6" type="stable">
-			<description>
+			<description translatable="no">
 				<p>Hide IP field when input is not a domain name.</p>
 			</description>
 		</release>
 		<release version="0.1.6" date="2023-06-5" type="stable">
-			<description>
+			<description translatable="no">
 				<p>Show IP if a domain name is given.</p>
 			</description>
 		</release>
 		<release version="0.1.5" date="2023-05-28" type="stable">
-			<description>
+			<description translatable="no">
 				<p>Ukrainian translation.</p>
 			</description>
 		</release>
 		<release version="0.1.4" date="2023-05-25" type="stable">
-			<description>
+			<description translatable="no">
 				<p>Italian and french translation.</p>
 			</description>
 		</release>
 		<release version="0.1.3" date="2023-05-16" type="stable">
-			<description>
+			<description translatable="no">
 				<p>Add translation support.</p>
 				<p>Add Turkish translation.</p>
 			</description>
 		</release>
 		<release version="0.1.2" date="2023-05-13" type="stable">
-			<description>
+			<description translatable="no">
 				<p>Move from com.github to io.github</p>
 			</description>
 		</release>
 		<release version="0.1.1" date="2023-05-13" type="stable">
-			<description>
+			<description translatable="no">
 				<p>Switch to org.gnome.Platform 44.</p>
 				<p>Add Desktop Entry category.</p>
 			</description>
 		</release>
 		<release version="0.1.0" date="2023-05-11" type="stable">
-			<description>
+			<description translatable="no">
 				<p>First version. Just working, nothing fancy.</p>
 			</description>
 		</release>

--- a/data/io.github.bytezz.IPLookup.appdata.xml.in
+++ b/data/io.github.bytezz.IPLookup.appdata.xml.in
@@ -7,7 +7,7 @@
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0-or-later</project_license>
 	<description>
-		<p>Find info about an IP address.</p>
+		<p>Find information about given IP address.</p>
 	</description>
 	<content_rating type="oars-1.1"/>
 	<launchable type="desktop-id">io.github.bytezz.IPLookup.desktop</launchable>

--- a/po/IPLookup-gtk.pot
+++ b/po/IPLookup-gtk.pot
@@ -1,0 +1,110 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-14 00:37+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/io.github.bytezz.IPLookup.desktop.in:3
+#: data/io.github.bytezz.IPLookup.appdata.xml.in:4 src/window.ui:8
+msgid "IP Lookup"
+msgstr ""
+
+#: data/io.github.bytezz.IPLookup.appdata.xml.in:5
+msgid "Find info about an IP address"
+msgstr ""
+
+#: data/io.github.bytezz.IPLookup.appdata.xml.in:10
+msgid "Find information about given IP address."
+msgstr ""
+
+#: data/io.github.bytezz.IPLookup.appdata.xml.in:18
+msgid "Main Window"
+msgstr ""
+
+#: src/window.ui:43 src/window.ui:64
+msgid "IP"
+msgstr ""
+
+#: src/window.ui:61 src/window.ui:77
+msgid "Network"
+msgstr ""
+
+#: src/window.ui:89
+msgid "ISP"
+msgstr ""
+
+#: src/window.ui:101
+msgid "Org"
+msgstr ""
+
+#: src/window.ui:115
+msgid "Geo"
+msgstr ""
+
+#: src/window.ui:119
+msgid "City"
+msgstr ""
+
+#: src/window.ui:131
+msgid "Region"
+msgstr ""
+
+#: src/window.ui:143
+msgid "Country"
+msgstr ""
+
+#: src/window.ui:155
+msgid "Zip"
+msgstr ""
+
+#: src/window.ui:167
+msgid "Timezone"
+msgstr ""
+
+#: src/window.ui:179
+msgid "Coordinates"
+msgstr ""
+
+#: src/window.ui:185
+msgid "Open map"
+msgstr ""
+
+#: src/window.ui:209
+msgid "_Keyboard Shortcuts"
+msgstr ""
+
+#: src/window.ui:213
+msgid "_About IP Lookup"
+msgstr ""
+
+#: src/window.ui:224
+msgid "_Close"
+msgstr ""
+
+#: src/gtk/help-overlay.ui:11
+msgctxt "shortcut window"
+msgid "General"
+msgstr ""
+
+#: src/gtk/help-overlay.ui:14
+msgctxt "shortcut window"
+msgid "Show Shortcuts"
+msgstr ""
+
+#: src/gtk/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr ""

--- a/po/IPLookup-gtk.pot
+++ b/po/IPLookup-gtk.pot
@@ -34,6 +34,10 @@ msgstr ""
 msgid "Main Window"
 msgstr ""
 
+#: src/main.py:65
+msgid "translator-credits"
+msgstr ""
+
 #: src/window.ui:43 src/window.ui:64
 msgid "IP"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,15 +1,15 @@
 # Turkish translation of io.github.bytezz.IPLookup.
-# Copyright (C) 2023 io.github.bytezz.IPLookup COPYRIGHT HOLDER
+# Copyright (C) 2023-2024 io.github.bytezz.IPLookup COPYRIGHT HOLDER
 # This file is distributed under the same license as the io.github.bytezz.IPLookup package.
 #
-# Sabri Ünal <libreajans@gmail.com>, 2023.
+# Sabri Ünal <libreajans@gmail.com>, 2023, 2024.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: io.github.bytezz.IPLookup\n"
 "Report-Msgid-Bugs-To: https://github.com/Bytezz/IPLookup-gtk/issues\n"
-"POT-Creation-Date: 2023-05-15 18:13+0300\n"
-"PO-Revision-Date: 2023-05-15 18:14+0300\n"
+"POT-Creation-Date: 2024-01-14 00:37+0300\n"
+"PO-Revision-Date: 2024-01-14 00:39+0300\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <takim@gnome.org.tr>\n"
 "Language: tr\n"
@@ -17,102 +17,84 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.1.1\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #: data/io.github.bytezz.IPLookup.desktop.in:3
-#: data/io.github.bytezz.IPLookup.appdata.xml.in:4
+#: data/io.github.bytezz.IPLookup.appdata.xml.in:4 src/window.ui:8
 msgid "IP Lookup"
 msgstr "IP Sorgula"
 
 #: data/io.github.bytezz.IPLookup.appdata.xml.in:5
-#: data/io.github.bytezz.IPLookup.appdata.xml.in:10
-msgid "Find info about an IP address."
-msgstr "IP adresleri hakkındaki bilgileri bul."
+msgid "Find info about an IP address"
+msgstr "IP adresleri hakkındaki bilgileri bul"
 
-#: data/io.github.bytezz.IPLookup.appdata.xml.in:17
+#: data/io.github.bytezz.IPLookup.appdata.xml.in:10
+msgid "Find information about given IP address."
+msgstr "Verilen IP adresi hakkında bilgileri bul."
+
+#: data/io.github.bytezz.IPLookup.appdata.xml.in:18
 msgid "Main Window"
 msgstr "Ana Pencere"
 
-#: data/io.github.bytezz.IPLookup.appdata.xml.in:37
+#: src/window.ui:43 src/window.ui:64
 msgid "IP"
 msgstr "IP"
 
-#: data/io.github.bytezz.IPLookup.appdata.xml.in:38
-msgid "lookup"
-msgstr "ara"
-
-#: data/io.github.bytezz.IPLookup.appdata.xml.in:39
-msgid "ISP"
-msgstr "Servis Sağlayıcı"
-
-#: data/io.github.bytezz.IPLookup.appdata.xml.in:40
-msgid "traceroute"
-msgstr "traceroute"
-
-#: data/io.github.bytezz.IPLookup.appdata.xml.in:54
-msgid "Move from com.github to io.github"
-msgstr "com.github yerine io.github kullanılmaya başlandı"
-
-#: data/io.github.bytezz.IPLookup.appdata.xml.in:59
-msgid "Switch to org.gnome.Platform 44."
-msgstr "GNOME 44 platformuna geçildi."
-
-#: data/io.github.bytezz.IPLookup.appdata.xml.in:60
-msgid "Add Desktop Entry category."
-msgstr "Masaüstü Girdisi kategorisi eklendi."
-
-#: data/io.github.bytezz.IPLookup.appdata.xml.in:65
-msgid "First version. Just working, nothing fancy."
-msgstr "İlk sürüm. Sadece çalışıyor, özel bir şey yok."
-
-#: src/window.ui:196
-msgid "_Keyboard Shortcuts"
-msgstr "_Klavye Kısayolları"
-
-#: src/window.ui:200
-msgid "_About IP Lookup"
-msgstr "IP Sorgula _Hakkında"
-
-#: src/window.ui:61
-#: src/window.ui:64
+#: src/window.ui:61 src/window.ui:77
 msgid "Network"
 msgstr "Ağ"
 
-#: src/window.ui:88
+#: src/window.ui:89
+msgid "ISP"
+msgstr "Servis Sağlayıcı"
+
+#: src/window.ui:101
 msgid "Org"
 msgstr "Kurum"
 
-#: src/window.ui:102
+#: src/window.ui:115
 msgid "Geo"
 msgstr "Konum"
 
-#: src/window.ui:106
+#: src/window.ui:119
 msgid "City"
 msgstr "Şehir"
 
-#: src/window.ui:116
+#: src/window.ui:131
 msgid "Region"
 msgstr "Bölge"
 
-#: src/window.ui:130
+#: src/window.ui:143
 msgid "Country"
 msgstr "Ülke"
 
-#: src/window.ui:142
+#: src/window.ui:155
 msgid "Zip"
 msgstr "Posta Kodu"
 
-#: src/window.ui:154
+#: src/window.ui:167
 msgid "Timezone"
 msgstr "Saat Dilimi"
 
-#: src/window.ui:166
+#: src/window.ui:179
 msgid "Coordinates"
 msgstr "Koordinatlar"
 
-#: src/window.ui:172
+#: src/window.ui:185
 msgid "Open map"
 msgstr "Haritayı aç"
+
+#: src/window.ui:209
+msgid "_Keyboard Shortcuts"
+msgstr "_Klavye Kısayolları"
+
+#: src/window.ui:213
+msgid "_About IP Lookup"
+msgstr "IP Sorgula _Hakkında"
+
+#: src/window.ui:224
+msgid "_Close"
+msgstr "_Kapat"
 
 #: src/gtk/help-overlay.ui:11
 msgctxt "shortcut window"

--- a/po/tr.po
+++ b/po/tr.po
@@ -36,6 +36,10 @@ msgstr "Verilen IP adresi hakkında bilgileri bul."
 msgid "Main Window"
 msgstr "Ana Pencere"
 
+#: src/main.py:65
+msgid "translator-credits"
+msgstr "Sabri Ünal <libreajans@gmail.com>"
+
 #: src/window.ui:43 src/window.ui:64
 msgid "IP"
 msgstr "IP"

--- a/src/main.py
+++ b/src/main.py
@@ -54,7 +54,7 @@ class IplookupApplication(Adw.Application):
     def on_quit_action(self, widget, _):
         self.quit()
 
-    def on_about_action(self, widget, _):
+    def on_about_action(self, *args):
         """Callback for the app.about action."""
         about = Adw.AboutWindow(transient_for=self.props.active_window,
                                 application_name='IP Lookup',
@@ -62,6 +62,7 @@ class IplookupApplication(Adw.Application):
                                 developer_name='Bytez',
                                 version='0.1.7',
                                 developers=['Bytez'],
+                                translator_credits=_("translator-credits"),
                                 copyright='© 2023 Bytez')
         about.present()
 

--- a/src/window.ui
+++ b/src/window.ui
@@ -5,7 +5,7 @@
   <template class="IplookupWindow" parent="AdwApplicationWindow">
     <property name="default-width">500</property>
     <property name="default-height">715</property>
-    <property name="title" translatable="true">IP Lookup</property>
+    <property name="title" translatable="yes">IP Lookup</property>
     <child>
       <object class="GtkBox">
         <property name="orientation">vertical</property>
@@ -40,7 +40,7 @@
                                 <child>
                                   <!-- TODO: Move this to headerbar as GtkEntry? -->
                                   <object class="AdwEntryRow" id="ip_entry">
-                                    <property name="title" translatable="true">IP</property>
+                                    <property name="title" translatable="yes">IP</property>
                                     <!-- Is possible to change apply-button icon? -->
                                     <property name="show-apply-button">True</property>
                                     <!--child>
@@ -58,10 +58,10 @@
                             </child>
                             <child>
                               <object class="AdwPreferencesGroup">
-                                <property name="title" translatable="true">Network</property>
+                                <property name="title" translatable="yes">Network</property>
                                 <child>
                                   <object class="AdwActionRow" id="ip_row">
-                                    <property name="title" translatable="true">IP</property>
+                                    <property name="title" translatable="yes">IP</property>
                                     <property name="icon-name">globe-symbolic</property>
                                     <property name="visible">False</property>
                                     <child>
@@ -74,7 +74,7 @@
                                 </child>
                                 <child>
                                   <object class="AdwActionRow">
-                                    <property name="title" translatable="true">Network</property>
+                                    <property name="title" translatable="yes">Network</property>
                                     <property name="icon-name">lan-symbolic</property>
                                     <child>
                                       <object class="GtkLabel" id="network_label">
@@ -86,7 +86,7 @@
                                 </child>
                                 <child>
                                   <object class="AdwActionRow">
-                                    <property name="title" translatable="true">ISP</property>
+                                    <property name="title" translatable="yes">ISP</property>
                                     <property name="icon-name">globe-symbolic</property>
                                     <child>
                                       <object class="GtkLabel" id="isp_label">
@@ -98,7 +98,7 @@
                                 </child>
                                 <child>
                                   <object class="AdwActionRow">
-                                    <property name="title" translatable="true">Org</property>
+                                    <property name="title" translatable="yes">Org</property>
                                     <property name="icon-name">building-symbolic</property>
                                     <child>
                                       <object class="GtkLabel" id="org_label">
@@ -112,11 +112,11 @@
                             </child>
                             <child>
                               <object class="AdwPreferencesGroup">
-                                <property name="title" translatable="true">Geo</property>
+                                <property name="title" translatable="yes">Geo</property>
                                 <property name="margin-bottom">10</property>
                                 <child>
                                   <object class="AdwActionRow">
-                                    <property name="title" translatable="true">City</property>
+                                    <property name="title" translatable="yes">City</property>
                                     <property name="icon-name">city-symbolic</property>
                                     <child>
                                       <object class="GtkLabel" id="city_label">
@@ -128,7 +128,7 @@
                                 </child>
                                 <child>
                                   <object class="AdwActionRow">
-                                    <property name="title" translatable="true">Region</property>
+                                    <property name="title" translatable="yes">Region</property>
                                     <property name="icon-name">flag-outline-thick-symbolic</property>
                                     <child>
                                       <object class="GtkLabel" id="region_label">
@@ -140,7 +140,7 @@
                                 </child>
                                 <child>
                                   <object class="AdwActionRow">
-                                    <property name="title" translatable="true">Country</property>
+                                    <property name="title" translatable="yes">Country</property>
                                     <property name="icon-name">flag-filled-symbolic</property>
                                     <child>
                                       <object class="GtkLabel" id="country_label">
@@ -152,7 +152,7 @@
                                 </child>
                                 <child>
                                   <object class="AdwActionRow">
-                                    <property name="title" translatable="true">Zip</property>
+                                    <property name="title" translatable="yes">Zip</property>
                                     <property name="icon-name">mail-symbolic</property>
                                     <child>
                                       <object class="GtkLabel" id="zip_label">
@@ -164,7 +164,7 @@
                                 </child>
                                 <child>
                                   <object class="AdwActionRow">
-                                    <property name="title" translatable="true">Timezone</property>
+                                    <property name="title" translatable="yes">Timezone</property>
                                     <property name="icon-name">clock-alt-symbolic</property>
                                     <child>
                                       <object class="GtkLabel" id="timezone_label">
@@ -176,13 +176,13 @@
                                 </child>
                                 <child>
                                   <object class="AdwActionRow">
-                                    <property name="title" translatable="true">Coordinates</property>
+                                    <property name="title" translatable="yes">Coordinates</property>
                                     <property name="icon-name">map-marker-symbolic</property>
                                     <child>
                                       <object class="GtkLinkButton" id="coordinates_label">
                                         <property name="label"></property>
                                         <property name="uri"></property>
-                                        <property name="tooltip-text" translatable="true">Open map</property>
+                                        <property name="tooltip-text" translatable="yes">Open map</property>
                                         <property name="visible">False</property>
                                       </object>
                                     </child>


### PR DESCRIPTION
### appdata: Update appdata

- Mark release descriptions as untranslatable
- Remove categories and keywords that already presented in the desktop file
- Add vcs-browser and translate URLs
- Remove one of Purism tag to pass appstreamcli validation
- Add default tag to one of screenshot
- Remove dot from summary
- Add translation tag

### ui: Mark translatable strings as yes

It's common to mark translatable strings as yes

### appdata: Don't repeat the summary

"The description should not just repeat or rephrase the summary.
The summary is a kind of slogan or advertisement for the app,
while the description should go into more detail about the purpose of
the app, which features it has, and what makes it unique."

Source: https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/quality-guidelines#dont-repeat-the-summary

### po: Create a POT file

### po: Update Turkish translation
