### PR TITLE
appdata: Add developer ID

### DIFF
--- a/data/io.github.bytezz.IPLookup.appdata.xml.in
+++ b/data/io.github.bytezz.IPLookup.appdata.xml.in
@@ -61,7 +61,7 @@
 
 	<releases>
 		<release version="0.3.3" date="2024-02-11" type="stable">
-			<description>
+			<description translate="no">
 				<ul>
 				  <li>Update Turkish translation</li>
 				  <li>Update Russian translation</li>
@@ -72,17 +72,17 @@
 			</description>
 		</release>
 		<release version="0.3.2" date="2023-11-18" type="stable">
-			<description>
+			<description translate="no">
 				<p>Add belarusian and update french translations.</p>
 			</description>
 		</release>
 		<release version="0.3.1" date="2023-11-08" type="stable">
-			<description>
+			<description translate="no">
 				<p>Update ukrainian and russian translations.</p>
 			</description>
 		</release>
 		<release version="0.3.0" date="2023-10-31" type="stable">
-			<description>
+			<description translate="no">
 				<p>Improve about window.</p>
 				<p>Port to AdwToolbarView.</p>
 				<p>Use toast.</p>
@@ -92,61 +92,61 @@
 			</description>
 		</release>
 		<release version="0.2.0" date="2023-10-27" type="stable">
-			<description>
+			<description translate="no">
 				<p>New icon! Thanks Jakub Steiner</p>
 				<p>Remember window size.</p>
 				<p>Add left and right margins.</p>
 			</description>
 		</release>
 		<release version="0.1.9" date="2023-10-6" type="stable">
-			<description>
+			<description translate="no">
 				<p>Update Ukrainian and add Russian translations.</p>
 			</description>
 		</release>
 		<release version="0.1.8" date="2023-10-6" type="stable">
-			<description>
+			<description translate="no">
 				<p>Update Turkish translation.</p>
 			</description>
 		</release>
 		<release version="0.1.7" date="2023-06-6" type="stable">
-			<description>
+			<description translate="no">
 				<p>Hide IP field when input is not a domain name.</p>
 			</description>
 		</release>
 		<release version="0.1.6" date="2023-06-5" type="stable">
-			<description>
+			<description translate="no">
 				<p>Show IP if a domain name is given.</p>
 			</description>
 		</release>
 		<release version="0.1.5" date="2023-05-28" type="stable">
-			<description>
+			<description translate="no">
 				<p>Ukrainian translation.</p>
 			</description>
 		</release>
 		<release version="0.1.4" date="2023-05-25" type="stable">
-			<description>
+			<description translate="no">
 				<p>Italian and french translation.</p>
 			</description>
 		</release>
 		<release version="0.1.3" date="2023-05-16" type="stable">
-			<description>
+			<description translate="no">
 				<p>Add translation support.</p>
 				<p>Add Turkish translation.</p>
 			</description>
 		</release>
 		<release version="0.1.2" date="2023-05-13" type="stable">
-			<description>
+			<description translate="no">
 				<p>Move from com.github to io.github</p>
 			</description>
 		</release>
 		<release version="0.1.1" date="2023-05-13" type="stable">
-			<description>
+			<description translate="no">
 				<p>Switch to org.gnome.Platform 44.</p>
 				<p>Add Desktop Entry category.</p>
 			</description>
 		</release>
 		<release version="0.1.0" date="2023-05-11" type="stable">
-			<description>
+			<description translate="no">
 				<p>First version. Just working, nothing fancy.</p>
 			</description>
 		</release>

--- a/data/io.github.bytezz.IPLookup.appdata.xml.in
+++ b/data/io.github.bytezz.IPLookup.appdata.xml.in
@@ -5,6 +5,9 @@
 	<summary>Find info about an IP address</summary>
 	<icon type="remote" width="16" height="16" scale="1">https://raw.githubusercontent.com/Bytezz/IPLookup-gtk/master/data/icons/hicolor/scalable/apps/io.github.bytezz.IPLookup.svg</icon>
 	<developer_name>Bytez</developer_name>
+	<developer id="io.github.bytezz">
+		<name>Bytez</name>
+	</developer>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0-or-later</project_license>
 	<description>


### PR DESCRIPTION
Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer