### PR TITLE
metainfo: add brand colors

### DIFF
--- a/data/io.github.bytezz.IPLookup.appdata.xml.in
+++ b/data/io.github.bytezz.IPLookup.appdata.xml.in
@@ -52,6 +52,11 @@
 	<url type="vcs-browser">https://github.com/bytezz/iplookup-gtk</url>
 	<url type="translate">https://github.com/Bytezz/IPLookup-gtk/tree/main/po</url>
 
+  	<branding>
+		<color type="primary" scheme_preference="light">#99c1f1</color>
+		<color type="primary" scheme_preference="dark">#123d72</color>
+	</branding>
+
 	<custom>
 		<value key="Purism::form_factor">mobile</value>
 	</custom>


### PR DESCRIPTION
Adds metainfo brand colors to meet the Flathub quality guidelines.

![image](https://github.com/Bytezz/IPLookup-gtk/assets/1908896/e366c048-75c0-46ed-8bd5-bd6c8de58070)
